### PR TITLE
fix puppetlabs-inifile version

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -9,4 +9,4 @@ project_page 'https://github.com/stephenrjohnson/puppetlabs-puppet'
 ## Add dependencies, if any:
 dependency 'puppetlabs/inifile', '>= 1.0.0'
 dependency 'puppetlabs/apache', '>= 0.8.0'
-dependency 'puppetlabs/puppetdb', '>= 1.1.5'
+dependency 'puppetlabs/puppetdb', '>= 2.0.0'


### PR DESCRIPTION
There is no 0.5.0 version of the puppetlabs-inifile module. http://forge.puppetlabs.com/puppetlabs/inifile

This is mostly not an issue since most module tools resolve it correctly but I had an issue with `puppet module install puppetlabs-inifile --version 0.5.0` in the rspec-system tests.
