### PR TITLE
Refactoring of agent service

### DIFF
--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -34,9 +34,9 @@ describe 'puppet::agent', :type => :class do
                         :require  => "Package[#{params[:puppet_agent_package]}]"
                     )
                     should contain_service(params[:puppet_agent_service]).with(
-                        :ensure  => true,
+                        :ensure  => 'running',
                         :enable  => true,
-                        :require => 'File[/etc/puppet/puppet.conf]'
+                        :require => "Package[#{params[:puppet_agent_package]}]"
                     )
                 }
             end
@@ -193,9 +193,9 @@ describe 'puppet::agent', :type => :class do
                         :require  => "Package[#{params[:puppet_agent_package]}]"
                     )
                     should contain_service(params[:puppet_agent_service]).with(
-                        :ensure  => true,
+                        :ensure  => 'running',
                         :enable  => true,
-                        :require => 'File[/etc/puppet/puppet.conf]'
+                        :require => "Package[#{params[:puppet_agent_package]}]"
                     )
                 }
             end


### PR DESCRIPTION
I added all the test stuff to be able to verify my fix that you implemented in bcf164eeb069296ad2c5072ee27776c8417f4d47 on Debian, but you beat me to it :)

This refactors things a bit so that the service is only declared once but with the parameters set conditionally based on which puppet_run_style you choose. There were some differences in how the service was declared, I picked a version that made most sense to me.
