### PR TITLE
Make rspec-system dependencies the same as in Modulefile

### DIFF
--- a/spec/spec_helper_system.rb
+++ b/spec/spec_helper_system.rb
@@ -20,9 +20,10 @@ RSpec.configure do |c|
         # Install puppet
         puppet_install
         puppet_module_install(:source => proj_root, :module_name => 'puppet')
-        shell('puppet module install puppetlabs-inifile --version 1.0.0')
-        shell('puppet module install puppetlabs-apache --version 0.8.0')
-        shell('puppet module install puppetlabs-puppetdb --version 1.1.5')
+        # Install dependencies from Modulefile
+        shell('puppet module install puppetlabs-inifile --version ">= 1.0.0"')
+        shell('puppet module install puppetlabs-apache --version ">= 0.8.0"')
+        shell('puppet module install puppetlabs-puppetdb --version ">= 2.0.0"')
         if node.facts['osfamily'] == 'Debian'
             shell('puppet module install puppetlabs-apt')
         end


### PR DESCRIPTION
I wasn't aware of that `puppet module install` could handle versions like `>= 1.0.0`. I updated the rspec-system helper to use the same values as in the Modulefile. It will have to be maintained alongside with the Modulefile since there's currently no helper to parse the Modulefile dependencies, but there is an open issue in rspec-system-puppet requesting handling that.
