### PR TITLE
Added support for alternate parser selection (eg. 'future').

### DIFF
--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -64,6 +64,7 @@ class puppet::master (
   $version                  = 'present',
   $apache_serveradmin       = $::puppet::params::apache_serveradmin,
   $pluginsync               = true,
+  $parser                   = $::puppet::params::parser,
   $puppetdb_startup_timeout = '60'
 ) inherits puppet::params {
 
@@ -215,6 +216,12 @@ class puppet::master (
     ensure  => present,
     setting => 'pluginsync',
     value   => $pluginsync,
+  }
+
+  ini_setting {'puppetmasterparser':
+    ensure  => present,
+    setting => 'parser',
+    value   => $parser,
   }
 
   if $reporturl != 'UNSET'{

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -26,6 +26,7 @@ class puppet::params {
   $puppet_server_port               = '8140'
   $puppet_agent_enabled             = true
   $apache_serveradmin               = 'root'
+  $parser                           = 'current'
 
   case $::osfamily {
     RedHat: {


### PR DESCRIPTION
This change will not affect existing initial configurations, but provides the ability to specify the 'future' parser if desire.  This also enables the selection of additional alternative parsers if such become available in the future.
