### PR TITLE
set ${puppet_ssldir}/ca to 770 instead of 750 - puppet agent resets to 770 anyway

### DIFF
--- a/manifests/passenger.pp
+++ b/manifests/passenger.pp
@@ -56,7 +56,7 @@ class puppet::passenger(
       ensure => directory,
       owner  => $::puppet::params::puppet_user,
       group  => $::puppet::params::puppet_group,
-      mode   => '0750',
+      mode   => '0770',
       before => Exec['Certificate_Check'],
     }
 


### PR DESCRIPTION
puppet agent (at least 3.3.1) resets /var/lib/puppet/ssl/ca to 0770, so lets use that instead so we dont keep flipping back and forth. :)

Notice: /Stage[main]/Puppet::Passenger/File[/var/lib/puppet/ssl/ca]/mode: mode changed '0770' to '0750'
