### PR TITLE
Typo Fix: Sample usage text in puppet::master

### DIFF
--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -42,7 +42,7 @@
 #
 #  class { "puppet::master":
 #    modulepath             => inline_template("<%= modulepath.join(':') %>"),
-#    storedcofnigs          => 'true',
+#    storeconfigs          => 'true',
 #  }
 #
 class puppet::master (


### PR DESCRIPTION
The parameter for storeconfig was spelt incorrectly.
