### PR TITLE
Make apache installation optional

### DIFF
--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -22,6 +22,7 @@
 #  ['puppet_master_service']    - Puppet master service
 #  ['version']                  - Version of the puppet master package to install
 #  ['apache_serveradmin']       - Apache server admin
+#  ['apache_install']           - Apache install
 #  ['pluginsync']               - Enable plugin sync
 #  ['parser']                   - Which parser to use
 #  ['puppetdb_startup_timeout'] - The timeout for puppetdb
@@ -65,6 +66,7 @@ class puppet::master (
   $puppet_master_service    = $::puppet::params::puppet_master_service,
   $version                  = 'present',
   $apache_serveradmin       = $::puppet::params::apache_serveradmin,
+  $apache_install           = true,
   $pluginsync               = true,
   $parser                   = $::puppet::params::parser,
   $puppetdb_startup_timeout = '60',
@@ -110,6 +112,7 @@ class puppet::master (
     puppet_passenger_port  => $puppet_passenger_port,
     puppet_docroot         => $puppet_docroot,
     apache_serveradmin     => $apache_serveradmin,
+    apache_install         => $apache_install,
     puppet_conf            => $::puppet::params::puppet_conf,
     puppet_ssldir          => $::puppet::params::puppet_ssldir,
     certname               => $certname,

--- a/manifests/passenger.pp
+++ b/manifests/passenger.pp
@@ -6,6 +6,7 @@
 #   ['puppet_passenger_port']    - The port for the virtual host
 #   ['puppet_docroot']           - Apache documnet root
 #   ['apache_serveradmin']       - The apache server admin
+#   ['apache_install']           - Apache install
 #   ['puppet_conf']              - The puppet config dir
 #   ['puppet_ssldir']            - The pupet ssl dir
 #   ['certname']                 - The puppet certname
@@ -34,15 +35,19 @@ class puppet::passenger(
   $puppet_passenger_port,
   $puppet_docroot,
   $apache_serveradmin,
+  $apache_install,
   $puppet_conf,
   $puppet_ssldir,
   $certname,
   $conf_dir
 ){
-  include apache
+  if $apache_install {
+    include apache
+    class { 'apache::mod::passenger': passenger_max_pool_size => 12, }
+    include apache::mod::ssl
+  }
+
   include puppet::params
-  class { 'apache::mod::passenger': passenger_max_pool_size => 12, }
-  include apache::mod::ssl
 
   if $::osfamily == 'redhat' {
     file{'/var/lib/puppet/reports':

--- a/spec/classes/puppet_passenger_spec.rb
+++ b/spec/classes/puppet_passenger_spec.rb
@@ -6,6 +6,7 @@ describe 'puppet::passenger', :type => :class do
                 :puppet_passenger_port  => '8140',
                 :puppet_docroot         => '/etc/puppet/rack/public/',
                 :apache_serveradmin     => 'root',
+                :apache_install         => true,
                 :puppet_conf            => '/etc/puppet/puppet.conf',
                 :puppet_ssldir          => '/var/lib/puppet/ssl',
                 :certname               => 'test.test.com',


### PR DESCRIPTION
As it stands it's not possible to get rid of the default apache settings (unless I am missing something obvious here).
