### PR TITLE
fix apache_custom_fragment template for apache2.4

### DIFF
--- a/templates/apache_custom_fragment.erb
+++ b/templates/apache_custom_fragment.erb
@@ -8,6 +8,10 @@
   <Directory /etc/puppet/rack/>
 	Options None
 	AllowOverride None
+    <%- if scope.lookupvar('apache::apache_version') == '2.4' -%>
+    Require all granted
+    <%- else -%>
 	Order allow,deny
-	allow from all
+    allow from all
+    <%- end -%>
   </Directory>


### PR DESCRIPTION
The module isn't working with Apache 2.4 right now. This will check the apache_version and use the correct permissions
