### PR TITLE
Added reportserver parameter for puppet agent to send transaction

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -21,6 +21,7 @@
 #   ['ordering']              - The way the agent processes resources. New feature in puppet 3.3.0
 #   ['trusted_node_data']     - Enable the trusted facts hash
 #   ['listen']                - If puppet agent should listen for connections
+#   ['reportserver']          - The server to send transaction reports to.
 #
 # Actions:
 # - Install and configures the puppet agent
@@ -54,6 +55,7 @@ class puppet::agent(
   $ordering               = undef,
   $trusted_node_data      = undef,
   $listen                 = false,
+  $reportserver           = undef,
 ) inherits puppet::params {
 
   if ! defined(User[$::puppet::params::puppet_user]) {
@@ -264,5 +266,10 @@ class puppet::agent(
     ensure  => present,
     setting => 'listen',
     value   => $listen,
+  }
+  ini_setting {'puppetagentreportserver':
+    ensure  => present,
+    setting => 'reportserver',
+    value   => $reportserver,
   }
 }


### PR DESCRIPTION
 reportserver parameter is required for puppet agent to send transaction reports.

This is required if reports need to be send to a different server.
