### PR TITLE
Add the ability to manage the digest_algorithm setting

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -22,6 +22,7 @@
 #   ['trusted_node_data']     - Enable the trusted facts hash
 #   ['listen']                - If puppet agent should listen for connections
 #   ['reportserver']          - The server to send transaction reports to.
+#   ['digest_algorithm']      - The algorithm to use for file digests.
 #
 # Actions:
 # - Install and configures the puppet agent
@@ -56,6 +57,7 @@ class puppet::agent(
   $trusted_node_data      = undef,
   $listen                 = false,
   $reportserver           = '$server',
+  $digest_algorithm       = $::puppet::params::digest_algorithm,
 ) inherits puppet::params {
 
   if ! defined(User[$::puppet::params::puppet_user]) {
@@ -271,5 +273,10 @@ class puppet::agent(
     ensure  => present,
     setting => 'reportserver',
     value   => $reportserver,
+  }
+  ini_setting {'puppetagentdigestalgorithm':
+    ensure  => present,
+    setting => 'digest_algorithm',
+    value   => $digest_algorithm,
   }
 }

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -29,6 +29,7 @@
 #  ['parser']                   - Which parser to use
 #  ['puppetdb_startup_timeout'] - The timeout for puppetdb
 #  ['dns_alt_names']            - Comma separated list of alternative DNS names
+#  ['digest_algorithm']         - The algorithm to use for file digests.
 #
 # Requires:
 #
@@ -77,6 +78,7 @@ class puppet::master (
   $puppetdb_startup_timeout   = '60',
   $puppetdb_strict_validation = $::puppet::params::puppetdb_strict_validation,
   $dns_alt_names              = ['puppet'],
+  $digest_algorithm           = $::puppet::params::digest_algorithm,
 ) inherits puppet::params {
 
   anchor { 'puppet::master::begin': }
@@ -271,6 +273,12 @@ class puppet::master (
       ensure  => present,
       setting => 'dns_alt_names',
       value   => join($dns_alt_names, ","),
+  }
+
+  ini_setting {'puppetmasterdigestalgorithm':
+      ensure  => present,
+      setting => 'digest_algorithm',
+      value   => $digest_algorithm,
   }
 
   anchor { 'puppet::master::end': }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -30,6 +30,7 @@ class puppet::params {
   $parser                           = 'current'
   $puppetdb_strict_validation       = true
   $environments                     = 'config'
+  $digest_algorithm                 = 'md5'
 
   # Only used when environments == directory
   $environmentpath                  = '$confdir/environments'


### PR DESCRIPTION
Please refer to http://docs.puppetlabs.com/puppet/3.6/reference/release_notes.html#feature-digestalgorithm-setting
This feature enables me to select SHA256 over MD5.
