### PR TITLE
Add the ability to not manage the Puppet agent service

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -8,7 +8,7 @@
 #   ['puppet_agent_service']  - The service the puppet agent runs under
 #   ['puppet_agent_package']  - The name of the package providing the puppet agent
 #   ['version']               - The version of the puppet agent to install
-#   ['puppet_run_style']      - The run style of the agent either cron or service
+#   ['puppet_run_style']      - The run style of the agent either 'service', 'cron', 'external' or 'manual'
 #   ['puppet_run_interval']   - The run interval of the puppet agent in minutes, default is 30 minutes
 #   ['user_id']               - The userid of the puppet user
 #   ['group_id']              - The groupid of the puppet group
@@ -83,7 +83,7 @@ class puppet::agent(
     $startonboot = 'no'
   }
 
-  if ($::osfamily == 'Debian') or ($::osfamily == 'Redhat') {
+  if ($::osfamily == 'Debian' and $puppet_run_style != 'manual') or ($::osfamily == 'Redhat') {
     file { $puppet::params::puppet_defaults:
       mode    => '0644',
       owner   => 'root',
@@ -132,18 +132,25 @@ class puppet::agent(
       $service_ensure = 'stopped'
       $service_enable = false
     }
+    # Do not manage the Puppet service and don't touch Debian's defaults file.
+    manual: {
+      $service_ensure = undef
+      $service_enable = undef
+    }
     default: {
       err 'Unsupported puppet run style in Class[\'puppet::agent\']'
     }
   }
 
-  service { $puppet_agent_service:
-    ensure     => $service_ensure,
-    enable     => $service_enable,
-    hasstatus  => true,
-    hasrestart => true,
-    subscribe  => [File[$::puppet::params::puppet_conf], File[$::puppet::params::confdir]],
-    require    => Package[$puppet_agent_package],
+  if $puppet_run_style != 'manual' {
+    service { $puppet_agent_service:
+      ensure     => $service_ensure,
+      enable     => $service_enable,
+      hasstatus  => true,
+      hasrestart => true,
+      subscribe  => [File[$::puppet::params::puppet_conf], File[$::puppet::params::confdir]],
+      require    => Package[$puppet_agent_package],
+    }
   }
 
   if ! defined(File[$::puppet::params::puppet_conf]) {

--- a/spec/system/agent_spec.rb
+++ b/spec/system/agent_spec.rb
@@ -68,7 +68,27 @@ describe 'agent tests:' do
             # by the agent module.
             it { should have_entry "* * * * \/usr\/bin\/puppet agent --no-daemonize --onetime --logdest syslog > \/dev\/null 2>&1" }
         end
+    end
 
+    context 'agent run style manual' do
+        it 'should work with no errors' do
+            pp = <<-EOS
+                class { 'puppet::agent':
+                    puppet_run_style => 'manual',
+                }
+            EOS
+
+            # Run it twice and test for idempotency
+            puppet_apply(pp) do |r|
+                r.exit_code.should_not == 1
+                r.refresh
+                r.exit_code.should be_zero
+            end
+        end
+
+        describe package('puppet') do
+            it { should be_installed }
+        end
     end
 
     context 'agent with external scheduler' do


### PR DESCRIPTION
In my environment we have our own tools to manage the state of the Puppet agent service and these two commits allows one to keep the current state of the agent service and not to touch the defaultsfile.
