### PR TITLE
Allow to unset environment setting

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -230,16 +230,22 @@ class puppet::agent(
     value   => $trusted_node_data,
   }
 
+  if $environment != undef
+  {
+    $environment_ensure = 'present'
+  } else {
+    $environment_ensure = 'absent'
+  }
   ini_setting {'puppetagentenvironment':
-    ensure  => present,
+    ensure  => $environment_ensure,
     setting => 'environment',
     value   => $environment,
   }
 
   ini_setting {'puppetagentmaster':
-    ensure   => present,
-    setting  => 'server',
-    value    => $puppet_server,
+    ensure  => present,
+    setting => 'server',
+    value   => $puppet_server,
   }
 
   ini_setting {'puppetagentuse_srv_records':

--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -574,5 +574,25 @@ describe 'puppet::agent', :type => :class do
         )
       }
     end
+    context 'with environment set to undef' do
+      let(:params) do
+        {
+          :environment => 'undef',
+        }
+      end
+
+      it {
+        should contain_ini_setting('puppetagentenvironment').with(
+          :ensure  => 'present',
+          :section => 'agent',
+          :path    => '/etc/puppet/puppet.conf'
+        )
+      }
+      it {
+        should contain_ini_setting('puppetagentenvironment').without(
+          :environment => 'production'
+        )
+      }
+    end
   end
 end


### PR DESCRIPTION
Added some logic to optionally remove the environment setting from the `puppet.conf` by setting `environment => undef`.
