### PR TITLE
fix sections settings for various configuration params

### DIFF
--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -217,7 +217,6 @@ class puppet::master (
     ensure  => $setting_config,
     setting => 'modulepath',
     value   => $modulepath,
-    section => 'main',
   }
   ini_setting {'puppetmastermanifest':
     ensure  => $setting_config,
@@ -280,7 +279,6 @@ class puppet::master (
     ensure  => present,
     setting => 'pluginsync',
     value   => $pluginsync,
-    section => 'agent',
   }
 
   ini_setting {'puppetmasterparser':
@@ -307,7 +305,6 @@ class puppet::master (
       ensure  => present,
       setting => 'digest_algorithm',
       value   => $digest_algorithm,
-      section => 'main',
   }
 
   anchor { 'puppet::master::end': }

--- a/spec/classes/puppet_master_spec.rb
+++ b/spec/classes/puppet_master_spec.rb
@@ -82,7 +82,6 @@ describe 'puppet::master', :type => :class do
             )
             should contain_ini_setting('puppetmastermodulepath').with(
                 :ensure  => 'present',
-                :section => 'main',
                 :setting => 'modulepath',
                 :path    => '/etc/puppet/puppet.conf',
                 :value   => params[:modulepath],
@@ -146,7 +145,6 @@ describe 'puppet::master', :type => :class do
             )
             should contain_ini_setting('puppetmasterpluginsync').with(
                 :ensure  => 'present',
-                :section => 'agent',
                 :setting => 'pluginsync',
                 :path    => '/etc/puppet/puppet.conf',
                 :value   => 'true'
@@ -243,7 +241,6 @@ describe 'puppet::master', :type => :class do
             )
             should contain_ini_setting('puppetmastermodulepath').with(
                 :ensure  => 'present',
-                :section => 'main',
                 :setting => 'modulepath',
                 :path    => '/etc/puppet/puppet.conf',
                 :value   => params[:modulepath],
@@ -307,7 +304,6 @@ describe 'puppet::master', :type => :class do
             )
             should contain_ini_setting('puppetmasterpluginsync').with(
                 :ensure  => 'present',
-                :section => 'agent',
                 :setting => 'pluginsync',
                 :path    => '/etc/puppet/puppet.conf',
                 :value   => 'true'
@@ -390,5 +386,5 @@ describe 'puppet::master', :type => :class do
             )
         }
     end
-        
+
 end


### PR DESCRIPTION
A number of `puppet.conf` settings were being put in the wrong sections of the file.  This PR fixes the incorrectly placed configuration items.

Fixes broken PR #69 (closed)
