### PR TITLE
fix for future parser

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -146,7 +146,7 @@ class puppet::agent(
       $service_enable = undef
     }
     default: {
-      err 'Unsupported puppet run style in Class[\'puppet::agent\']'
+      err('Unsupported puppet run style in Class[\'puppet::agent\']')
     }
   }
 


### PR DESCRIPTION
I had to add the following braces to support the future parser in your puppet::agent class (also works with the old parser)
