### PR TITLE
move cron command to class parameter

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -10,6 +10,7 @@
 #   ['version']               - The version of the puppet agent to install
 #   ['puppet_run_style']      - The run style of the agent either 'service', 'cron', 'external' or 'manual'
 #   ['puppet_run_interval']   - The run interval of the puppet agent in minutes, default is 30 minutes
+#   ['puppet_run_command']    - The command that will be executed for puppet agent run
 #   ['user_id']               - The userid of the puppet user
 #   ['group_id']              - The groupid of the puppet group
 #   ['splay']                 - If splay should be enable defaults to false
@@ -48,6 +49,7 @@ class puppet::agent(
   $version                = 'present',
   $puppet_run_style       = 'service',
   $puppet_run_interval    = 30,
+  $puppet_run_command     = '/usr/bin/puppet agent --no-daemonize --onetime --logdest syslog > /dev/null 2>&1',
   $user_id                = undef,
   $group_id               = undef,
   $splay                  = false,
@@ -128,7 +130,7 @@ class puppet::agent(
       $time2  =  fqdn_rand($puppet_run_interval) + 30
 
       cron { 'puppet-client':
-        command => '/usr/bin/puppet agent --no-daemonize --onetime --logdest syslog > /dev/null 2>&1',
+        command => $puppet_run_command,
         user    => 'root',
         # run twice an hour, at a random minute in order not to collectively stress the puppetmaster
         hour    => '*',


### PR DESCRIPTION
Hello!

I've made a simple fix for customizing puppet run command for cron configuration.
We are still using Ubuntu 12.04 and we need to install python packages via pip. But pip has pesky bug, ignoring proxy settings other, than managed via envitonment variables. So, for our nodes I run puppet this way:

``` yaml
puppet::agent::puppet_run_command: '/bin/sh -c "export http_proxy=http://proxy.example.com:3128 && export https_proxy=proxy.example.com:3128 && /usr/bin/puppet agent --no-daemonize --onetime --logdest syslog > /dev/null 2>&1"'
```

Also, this way anyone can customize agent parameters, redirections and other stuff.
