### PR TITLE
Set correct perms for a couple of puppet directories

### DIFF
--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -177,11 +177,12 @@ class puppet::master (
   }
 
   file { $puppet_vardir:
-    ensure       => directory,
-    owner        => $::puppet::params::puppet_user,
-    group        => $::puppet::params::puppet_group,
-    notify       => Service['httpd'],
-    require      => Package[$puppet_master_package]
+    ensure  => directory,
+    owner   => $::puppet::params::puppet_user,
+    group   => $::puppet::params::puppet_group,
+    mode    => '0750',
+    notify  => Service['httpd'],
+    require => Package[$puppet_master_package]
   }
 
   if $storeconfigs {

--- a/manifests/passenger.pp
+++ b/manifests/passenger.pp
@@ -53,6 +53,7 @@ class puppet::passenger(
       ensure => directory,
       owner  => $::puppet::params::puppet_user,
       group  => $::puppet::params::puppet_group,
+      mode   => '0750',
     }
   }
 


### PR DESCRIPTION
I set default properties for the file resource in my site manifest, as follows:

```
File{
  owner => 'root',
  group => 'root',
  mode  => '0644',
}
```

I noticed that a couple of the file resources in your module don't file mode and so get set to 0755 instead of the 0750 that they get installed as.

This fixes the issue.

Alternatively, it might be worth considering not managing those directories as they are both created by the install process (for the RPM, at least).
