### PR TITLE
Add strict variables

### DIFF
--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -87,7 +87,7 @@ class puppet::master (
   $dns_alt_names              = ['puppet'],
   $digest_algorithm           = $::puppet::params::digest_algorithm,
   $generate_ssl_certs         = true,
-  $strict_variables           = false,
+  $strict_variables           = undef,
 ) inherits puppet::params {
 
   anchor { 'puppet::master::begin': }
@@ -123,8 +123,6 @@ class puppet::master (
       ensure         => $version,
     }
   }
-
-  validate_bool($strict_variables)
 
   Anchor['puppet::master::begin'] ->
   class {'puppet::passenger':
@@ -316,10 +314,13 @@ class puppet::master (
       value   => $digest_algorithm,
   }
 
-  ini_setting {'puppetmasterstrictvariables':
-      ensure  => present,
-      setting => 'strict_variables',
-      value   => $strict_variables,
+  if $strict_variables != undef {
+    validate_bool($strict_variables)
+    ini_setting {'puppetmasterstrictvariables':
+        ensure  => present,
+        setting => 'strict_variables',
+        value   => $strict_variables,
+    }
   }
 
   anchor { 'puppet::master::end': }

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -33,6 +33,7 @@
 #  ['dns_alt_names']            - Comma separated list of alternative DNS names
 #  ['digest_algorithm']         - The algorithm to use for file digests.
 #  ['generate_ssl_certs']       - Generate ssl certs (false to disable)
+#  ['strict_variables']         - Makes the parser raise errors when referencing unknown variables
 #
 # Requires:
 #
@@ -86,6 +87,7 @@ class puppet::master (
   $dns_alt_names              = ['puppet'],
   $digest_algorithm           = $::puppet::params::digest_algorithm,
   $generate_ssl_certs         = true,
+  $strict_variables           = false,
 ) inherits puppet::params {
 
   anchor { 'puppet::master::begin': }
@@ -121,6 +123,8 @@ class puppet::master (
       ensure         => $version,
     }
   }
+
+  validate_bool($strict_variables)
 
   Anchor['puppet::master::begin'] ->
   class {'puppet::passenger':
@@ -310,6 +314,12 @@ class puppet::master (
       ensure  => present,
       setting => 'digest_algorithm',
       value   => $digest_algorithm,
+  }
+
+  ini_setting {'puppetmasterstrictvariables':
+      ensure  => present,
+      setting => 'strict_variables',
+      value   => $strict_variables,
   }
 
   anchor { 'puppet::master::end': }

--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -315,7 +315,7 @@ class puppet::master (
   }
 
   if $strict_variables != undef {
-    validate_bool($strict_variables)
+    validate_bool(str2bool($strict_variables))
     ini_setting {'puppetmasterstrictvariables':
         ensure  => present,
         setting => 'strict_variables',

--- a/spec/classes/puppet_master_spec.rb
+++ b/spec/classes/puppet_master_spec.rb
@@ -24,7 +24,8 @@ describe 'puppet::master', :type => :class do
                 :certname               => 'test.example.com',
                 :storeconfigs           => 'true',
                 :storeconfigs_dbserver  => 'test.example.com',
-                :dns_alt_names          => ['puppet']
+                :dns_alt_names          => ['puppet'],
+                :strict_variables       => 'true'
 
             }
         end
@@ -156,6 +157,13 @@ describe 'puppet::master', :type => :class do
                 :path    => '/etc/puppet/puppet.conf',
                 :value   => params[:dns_alt_names].join(',')
             )
+            should contain_ini_setting('puppetmasterstrictvariables').with(
+                :ensure  => 'present',
+                :section => 'master',
+                :setting => 'strict_variables',
+                :path    => '/etc/puppet/puppet.conf',
+                :value   => params[:strict_variables]
+            )
             should contain_anchor('puppet::master::begin').with_before(
               ['Class[Puppet::Passenger]', 'Class[Puppet::Storeconfigs]']
             )
@@ -185,7 +193,8 @@ describe 'puppet::master', :type => :class do
                 :certname               => 'test.example.com',
                 :storeconfigs           => 'true',
                 :storeconfigs_dbserver  => 'test.example.com',
-                :dns_alt_names          => ['puppet']
+                :dns_alt_names          => ['puppet'],
+                :strict_variables       => 'true'
 
             }
         end
@@ -314,6 +323,13 @@ describe 'puppet::master', :type => :class do
                 :setting => 'dns_alt_names',
                 :path    => '/etc/puppet/puppet.conf',
                 :value   => params[:dns_alt_names].join(',')
+            )
+            should contain_ini_setting('puppetmasterstrictvariables').with(
+                :ensure  => 'present',
+                :section => 'master',
+                :setting => 'strict_variables',
+                :path    => '/etc/puppet/puppet.conf',
+                :value   => params[:strict_variables]
             )
             should contain_anchor('puppet::master::begin').with_before(
               ['Class[Puppet::Passenger]', 'Class[Puppet::Storeconfigs]']


### PR DESCRIPTION
I think this should continue to work on versions of puppet without the strict_variables config option, if the user doesn't specify ```strict_variables => ...``` in the puppet::master class.