### PR TITLE
Fix variable name typo

### DIFF
--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -190,7 +190,7 @@ class puppet::master (
       dbserver                   => $storeconfigs_dbserver,
       dbport                     => $storeconfigs_dbport,
       puppet_service             => Service['httpd'],
-      puppet_confdir             => $::puppet::params::puppet_confdir,
+      puppet_confdir             => $::puppet::params::confdir,
       puppet_conf                => $::puppet::params::puppet_conf,
       puppet_master_package      => $puppet_master_package,
       puppetdb_startup_timeout   => $puppetdb_startup_timeout,


### PR DESCRIPTION
I identified this typo when I turned on strict_variables.