### PR TITLE
Add puppetdb_version parameter to master,storeconfigs & tests

### DIFF
--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -86,6 +86,7 @@ class puppet::master (
   $dns_alt_names              = ['puppet'],
   $digest_algorithm           = $::puppet::params::digest_algorithm,
   $generate_ssl_certs         = true,
+  $puppetdb_version           = 'present',
 ) inherits puppet::params {
 
   anchor { 'puppet::master::begin': }
@@ -195,6 +196,7 @@ class puppet::master (
       puppet_master_package      => $puppet_master_package,
       puppetdb_startup_timeout   => $puppetdb_startup_timeout,
       puppetdb_strict_validation => $puppetdb_strict_validation,
+      puppetdb_version           => $puppetdb_version,
     } ->
     Anchor['puppet::master::end']
   }

--- a/manifests/storeconfigs.pp
+++ b/manifests/storeconfigs.pp
@@ -27,14 +27,15 @@
 #   }
 #
 class puppet::storeconfigs(
-    $dbserver,
     $dbport,
-    $puppet_service,
+    $dbserver,
     $puppet_master_package,
+    $puppet_service,
     $puppetdb_startup_timeout,
     $puppetdb_strict_validation,
+    $puppetdb_version,
+    $puppet_conf    =  $::puppet::params::puppet_conf,
     $puppet_confdir =  $::puppet::params::confdir,
-    $puppet_conf    =  $::puppet::params::puppet_conf
 )inherits puppet::params {
 
   ##If we point at a puppetdb on this machine
@@ -57,6 +58,7 @@ class puppet::storeconfigs(
       puppetdb_startup_timeout => $puppetdb_startup_timeout,
       strict_validation        => $puppetdb_strict_validation,
       require                  => $require,
+      puppetdb_version         => $puppetdb_version,
     }
   }
 }

--- a/spec/classes/puppet_storeconfigs_spec.rb
+++ b/spec/classes/puppet_storeconfigs_spec.rb
@@ -18,7 +18,8 @@ describe 'puppet::storeconfigs', :type => :class do
                 :puppet_conf           => '/etc/puppet/puppet.conf',
                 :puppet_master_package => 'puppstmaster',
                 :puppetdb_startup_timeout => '60',
-                :puppetdb_strict_validation => true
+                :puppetdb_strict_validation => true,
+                :puppetdb_version => 'present'
             }
         end
 
@@ -44,7 +45,8 @@ describe 'puppet::storeconfigs', :type => :class do
                 :puppet_conf           => '/etc/puppet/puppet.conf',
                 :puppet_master_package => 'puppstmaster',
                 :puppetdb_startup_timeout => '60',
-                :puppetdb_strict_validation => true
+                :puppetdb_strict_validation => true,
+                :puppetdb_version => 'present'
             }
         end
 

--- a/tests/storedconfigs.pp
+++ b/tests/storedconfigs.pp
@@ -1,5 +1,6 @@
 class {'puppet::storeconfigs':
   dbserver => 'test.example.com',
   dbport => '8081',
-  puppet_service => Service['httpd']
+  puppet_service => Service['httpd'],
+  puppetdb_version => 'present'
 }


### PR DESCRIPTION
Sorry about that...

This was so I could specify what version to install for puppetdb-terminus, I also alphabetized the storeconfigs parameters.