### PR TITLE
Add options to puppet config

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -52,6 +52,7 @@ class puppet::agent(
 
   #[main]
   $templatedir            = undef,
+  $syslogfacility         = undef,
 
   #[agent]
   $srv_domain             = undef,
@@ -347,6 +348,14 @@ class puppet::agent(
       ensure  => present,
       setting => 'usecacheonfailure',
       value   => $usecacheonfailure,
+    }
+  }
+  if $syslogfacility != undef {
+    ini_setting {'puppetagentsyslogfacility':
+      ensure  => present,
+      setting => 'syslogfacility',
+      value   => $syslogfacility,
+      section => 'main',
     }
   }
 }

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -72,7 +72,7 @@ class puppet::agent(
   $configtimeout          = '2m',
   $stringify_facts        = undef,
   $verbose                = undef,
-  $noop                   = undef,
+  $agent_noop             = undef,
   $usecacheonfailure      = undef,
   $certname               = undef,
 ) inherits puppet::params {
@@ -337,11 +337,11 @@ class puppet::agent(
       value   => $verbose,
     }
   }
-  if $noop != undef {
+  if $agent_noop != undef {
     ini_setting {'puppetagentnoop':
       ensure  => present,
       setting => 'noop',
-      value   => $noop,
+      value   => $agent_noop,
     }
   }
   if $usecacheonfailure != undef {

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -42,25 +42,29 @@
 #   }
 #
 class puppet::agent(
-  $puppet_server          = $::puppet::params::puppet_server,
-  $puppet_server_port     = $::puppet::params::puppet_server_port,
   $puppet_agent_service   = $::puppet::params::puppet_agent_service,
   $puppet_agent_package   = $::puppet::params::puppet_agent_package,
   $version                = 'present',
   $puppet_run_style       = 'service',
-  $puppet_run_interval    = 30,
   $puppet_run_command     = '/usr/bin/puppet agent --no-daemonize --onetime --logdest syslog > /dev/null 2>&1',
   $user_id                = undef,
   $group_id               = undef,
-  $splay                  = false,
-  $environment            = 'production',
-  $report                 = true,
-  $pluginsync             = true,
-  $use_srv_records        = false,
+
+  #[main]
+  $templatedir            = undef,
+
+  #[agent]
   $srv_domain             = undef,
   $ordering               = undef,
-  $templatedir            = undef,
   $trusted_node_data      = undef,
+  $environment            = 'production',
+  $puppet_server          = $::puppet::params::puppet_server,
+  $use_srv_records        = false,
+  $puppet_run_interval    = 30,
+  $splay                  = false,
+  $puppet_server_port     = $::puppet::params::puppet_server_port,
+  $report                 = true,
+  $pluginsync             = true,
   $listen                 = false,
   $reportserver           = '$server',
   $digest_algorithm       = $::puppet::params::digest_algorithm,

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -53,6 +53,7 @@ class puppet::agent(
   #[main]
   $templatedir            = undef,
   $syslogfacility         = undef,
+  $priority               = undef,
 
   #[agent]
   $srv_domain             = undef,
@@ -364,6 +365,14 @@ class puppet::agent(
       ensure  => present,
       setting => 'certname',
       value   => $certname,
+    }
+  }
+  if $priority != undef {
+    ini_setting {'puppetagentpriority':
+      ensure  => present,
+      setting => 'priority',
+      value   => $priority,
+      section => 'main',
     }
   }
 }

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -74,6 +74,7 @@ class puppet::agent(
   $verbose                = undef,
   $noop                   = undef,
   $usecacheonfailure      = undef,
+  $certname               = undef,
 ) inherits puppet::params {
 
   if ! defined(User[$::puppet::params::puppet_user]) {
@@ -356,6 +357,13 @@ class puppet::agent(
       setting => 'syslogfacility',
       value   => $syslogfacility,
       section => 'main',
+    }
+  }
+  if $certname != undef {
+    ini_setting {'puppetagentcertname':
+      ensure  => present,
+      setting => 'certname',
+      value   => $certname,
     }
   }
 }

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -70,6 +70,9 @@ class puppet::agent(
   $digest_algorithm       = $::puppet::params::digest_algorithm,
   $configtimeout          = '2m',
   $stringify_facts        = undef,
+  $verbose                = undef,
+  $noop                   = undef,
+  $usecacheonfailure      = undef,
 ) inherits puppet::params {
 
   if ! defined(User[$::puppet::params::puppet_user]) {
@@ -323,6 +326,27 @@ class puppet::agent(
       ensure  => present,
       setting => 'stringify_facts',
       value   => $stringify_facts,
+    }
+  }
+  if $verbose != undef {
+    ini_setting {'puppetagentverbose':
+      ensure  => present,
+      setting => 'verbose',
+      value   => $verbose,
+    }
+  }
+  if $noop != undef {
+    ini_setting {'puppetagentnoop':
+      ensure  => present,
+      setting => 'noop',
+      value   => $noop,
+    }
+  }
+  if $usecacheonfailure != undef {
+    ini_setting {'puppetagentusecacheonfailure':
+      ensure  => present,
+      setting => 'usecacheonfailure',
+      value   => $usecacheonfailure,
     }
   }
 }


### PR DESCRIPTION
Six new options:
 - agent_noop
 - verbose
 - usecacheonfailure
 - syslogfacility
 - certname
 - priority

Also: Differentiate which config are in the [main] section, and which are in the [agent] section