### PR TITLE
Add support for http_proxy_host and http_proxy_port options

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -27,6 +27,8 @@
 #   ['templatedir']           - Template dir, if unset it will remove the setting.
 #   ['configtimeout']         - How long the client should wait for the configuration to be retrieved before considering it a failure
 #   ['stringify_facts']       - Wether puppet transforms structured facts in strings or no. Defaults to true in puppet < 4, deprecated in puppet >=4 (and will default to false)
+#   ['http_proxy_host']       - The hostname of an HTTP proxy to use for agent -> master connections
+#   ['http_proxy_port']       - The port to use when puppet uses an HTTP proxy
 #
 # Actions:
 # - Install and configures the puppet agent
@@ -76,6 +78,8 @@ class puppet::agent(
   $agent_noop             = undef,
   $usecacheonfailure      = undef,
   $certname               = undef,
+  $http_proxy_host        = undef,
+  $http_proxy_port        = undef,
 ) inherits puppet::params {
 
   if ! defined(User[$::puppet::params::puppet_user]) {
@@ -373,6 +377,20 @@ class puppet::agent(
       setting => 'priority',
       value   => $priority,
       section => 'main',
+    }
+  }
+  if $http_proxy_host != undef {
+    ini_setting {'puppetagenthttpproxyhost':
+      ensure  => present,
+      setting => 'http_proxy_host',
+      value   => $http_proxy_host,
+    }
+  }
+  if $http_proxy_port != undef {
+    ini_setting {'puppetagenthttpproxyport':
+      ensure  => present,
+      setting => 'http_proxy_port',
+      value   => $http_proxy_port,
     }
   }
 }

--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -575,4 +575,56 @@ describe 'puppet::agent', :type => :class do
       }
     end
   end
+  describe 'puppetagenthttpproxyhost' do
+    let(:facts) do
+      {
+        :osfamily        => 'RedHat',
+        :operatingsystem => 'RedHat',
+        :kernel          => 'Linux'
+      }
+    end
+    context 'with http_proxy_host set' do
+      let(:params) do
+        {
+          :http_proxy_host => 'proxy.example.com',
+        }
+      end
+
+      it{
+        should contain_ini_setting('puppetagenthttpproxyhost').with(
+          :ensure  => 'present',
+          :section => 'agent',
+          :setting => 'http_proxy_host',
+          :value   => 'proxy.example.com',
+          :path    => '/etc/puppet/puppet.conf'
+        )
+      }
+    end
+  end
+  describe 'puppetagenthttpproxyport' do
+    let(:facts) do
+      {
+        :osfamily        => 'RedHat',
+        :operatingsystem => 'RedHat',
+        :kernel          => 'Linux'
+      }
+    end
+    context 'with http_proxy_port set' do
+      let(:params) do
+        {
+          :http_proxy_port => '1234',
+        }
+      end
+
+      it{
+        should contain_ini_setting('puppetagenthttpproxyport').with(
+          :ensure  => 'present',
+          :section => 'agent',
+          :setting => 'http_proxy_port',
+          :value   => '1234',
+          :path    => '/etc/puppet/puppet.conf'
+        )
+      }
+    end
+  end
 end


### PR DESCRIPTION
Adding support for http_proxy_host and http_proxy_port in the [agent] section