### PR TITLE
Allow full cron specification for minute / hour

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -81,7 +81,7 @@ class puppet::agent(
   $http_proxy_host        = undef,
   $http_proxy_port        = undef,
   $cron_hour              = '*',
-  $cron_minute            = undef, 
+  $cron_minute            = undef,
 ) inherits puppet::params {
 
   if ! defined(User[$::puppet::params::puppet_user]) {

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -27,6 +27,8 @@
 #   ['templatedir']           - Template dir, if unset it will remove the setting.
 #   ['configtimeout']         - How long the client should wait for the configuration to be retrieved before considering it a failure
 #   ['stringify_facts']       - Wether puppet transforms structured facts in strings or no. Defaults to true in puppet < 4, deprecated in puppet >=4 (and will default to false)
+#   ['cron_hour']             - What hour to run if puppet_run_style is cron
+#   ['cron_minute']           - What minute to run if puppet_run_style is cron
 #
 # Actions:
 # - Install and configures the puppet agent
@@ -78,6 +80,8 @@ class puppet::agent(
   $certname               = undef,
   $http_proxy_host        = undef,
   $http_proxy_port        = undef,
+  $cron_hour              = '*',
+  $cron_minute            = '*/30',
 ) inherits puppet::params {
 
   if ! defined(User[$::puppet::params::puppet_user]) {
@@ -135,18 +139,11 @@ class puppet::agent(
       $service_ensure = 'stopped'
       $service_enable = false
 
-      # Run puppet as a cron - this saves memory and avoids the whole problem
-      # where puppet locks up for no reason. Also spreads out the run intervals
-      # more uniformly.
-      $time1  =  fqdn_rand($puppet_run_interval)
-      $time2  =  fqdn_rand($puppet_run_interval) + 30
-
       cron { 'puppet-client':
         command => $puppet_run_command,
         user    => 'root',
-        # run twice an hour, at a random minute in order not to collectively stress the puppetmaster
-        hour    => '*',
-        minute  => [ $time1, $time2 ],
+        hour    => $cron_hour,
+        minute  => $cron_minute,
       }
     }
     # Run Puppet through external tooling, like MCollective

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -81,7 +81,7 @@ class puppet::agent(
   $http_proxy_host        = undef,
   $http_proxy_port        = undef,
   $cron_hour              = '*',
-  $cron_minute            = '*/30',
+  $cron_minute            = undef, 
 ) inherits puppet::params {
 
   if ! defined(User[$::puppet::params::puppet_user]) {
@@ -139,11 +139,21 @@ class puppet::agent(
       $service_ensure = 'stopped'
       $service_enable = false
 
+      # Default to every 30 minutes - random around the clock
+      if $cron_minute == undef {
+        $time1  =  fqdn_rand(30)
+        $time2  =  $time1 + 30
+        $minute = [ $time1, $time2 ]
+      }
+      else {
+        $minute = $cron_minute
+      }
+
       cron { 'puppet-client':
         command => $puppet_run_command,
         user    => 'root',
         hour    => $cron_hour,
-        minute  => $cron_minute,
+        minute  => $minute,
       }
     }
     # Run Puppet through external tooling, like MCollective

--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -50,8 +50,9 @@ describe 'puppet::agent', :type => :class do
             :puppet_run_style       => 'cron',
             :splay                  => 'true',
             :environment            => 'production',
-            :puppet_run_interval    => 30,
             :puppet_server_port     => 8140,
+            :cron_hour              => 5,
+            :cron_minute            => '*/30',
           }
         end
         it{
@@ -69,8 +70,9 @@ describe 'puppet::agent', :type => :class do
           )
           should contain_cron('puppet-client').with(
             :command  => '/usr/bin/puppet agent --no-daemonize --onetime --logdest syslog > /dev/null 2>&1',
-            :user  => 'root',
-            :hour => '*'
+            :user     => 'root',
+            :hour     => '5'
+            :minute   => '*/30'
           )
         }
       end

--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -71,7 +71,7 @@ describe 'puppet::agent', :type => :class do
           should contain_cron('puppet-client').with(
             :command  => '/usr/bin/puppet agent --no-daemonize --onetime --logdest syslog > /dev/null 2>&1',
             :user     => 'root',
-            :hour     => '5'
+            :hour     => '5',
             :minute   => '*/30'
           )
         }


### PR DESCRIPTION
Fix for Issue 97 - this lets you specify the hour and minutes that a cron'd up puppet agent will activate, rather than hard coding to every 30 minutes.