### PR TITLE
Added option to passenger to add custom stuff on the config.ru file.

### DIFF
--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -77,6 +77,7 @@ class puppet::master (
   $puppet_vardir              = $::puppet::params::puppet_vardir,
   $puppet_passenger_port      = $::puppet::params::puppet_passenger_port,
   $puppet_passenger_tempdir   = false,
+  $puppet_passenger_cfg_addon = '',
   $puppet_master_package      = $::puppet::params::puppet_master_package,
   $puppet_master_service      = $::puppet::params::puppet_master_service,
   $version                    = 'present',
@@ -91,6 +92,7 @@ class puppet::master (
   $strict_variables           = undef,
   $puppetdb_version           = 'present',
   $always_cache_features      = false,
+
 ) inherits puppet::params {
 
   anchor { 'puppet::master::begin': }
@@ -139,6 +141,7 @@ class puppet::master (
     dns_alt_names            => join($dns_alt_names,','),
     generate_ssl_certs       => $generate_ssl_certs,
     puppet_passenger_tempdir => $puppet_passenger_tempdir,
+    config_addon             => $puppet_passenger_cfg_addon,
   } ->
   Anchor['puppet::master::end']
 

--- a/manifests/passenger.pp
+++ b/manifests/passenger.pp
@@ -41,7 +41,8 @@ class puppet::passenger(
   $puppet_ssldir,
   $certname,
   $conf_dir,
-  $dns_alt_names
+  $dns_alt_names,
+  $config_addon = ''
 ){
   include apache
   include puppet::params

--- a/templates/config.erb
+++ b/templates/config.erb
@@ -26,7 +26,7 @@ ARGV << "--rack"
 # to ~puppet/.puppet
 ARGV << "--confdir" << "/etc/puppet"
 ARGV << "--vardir"  << "/var/lib/puppet"
-
+<%= @config_addon %>
 # NOTE: it's unfortunate that we have to use the "CommandLine" class
 #  here to launch the app, but it contains some initialization logic
 #  (such as triggering the parsing of the config file) that is very


### PR DESCRIPTION
This allows, for example, to add the line 'ARGV << "--profile"'
needed for workaround with Puppet/Centos.
See for example
http://comments.gmane.org/gmane.comp.sysutils.puppet.user/65767