### PR TITLE
Allow puppet package install from alternate providers

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -49,6 +49,7 @@ class puppet::agent(
   $puppet_run_command     = '/usr/bin/puppet agent --no-daemonize --onetime --logdest syslog > /dev/null 2>&1',
   $user_id                = undef,
   $group_id               = undef,
+  $package_provider       = $::puppet::params::package_provider,
 
   #[main]
   $templatedir            = undef,
@@ -96,6 +97,7 @@ class puppet::agent(
   }
   package { $puppet_agent_package:
     ensure   => $version,
+    provider => $package_provider,
   }
 
   if $puppet_run_style == 'service' {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -31,6 +31,7 @@ class puppet::params {
   $puppetdb_strict_validation       = true
   $environments                     = 'config'
   $digest_algorithm                 = 'md5'
+  $package_provider                 = undef # falls back to system default
 
   # Only used when environments == directory
   $environmentpath                  = "${confdir}/environments"


### PR DESCRIPTION
We've entered a world where we want to install Puppet via Gem instead of yum/apt. This simple change will allow us to install it that way.