### PR TITLE
Larger travis test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+bundler_args: --without system_tests
 rvm:
   - 1.9.3
   - 2.0.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,9 @@ rvm:
   - 1.9.3
   - 2.0.0
 script: "bundle exec rake test"
+env:
+  matrix:
+    - PUPPET_GEM_VERSION="~> 3.7.0"
+    - PUPPET_GEM_VERSION="~> 3.7.0" FUTURE_PARSER="yes" STRICT_VARIABLES="no"
+    - PUPPET_GEM_VERSION="~> 3.7.0" FUTURE_PARSER="yes" STRICT_VARIABLES="yes"
+    - PUPPET_GEM_VERSION="~> 4.0.0"

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,11 @@
 # A sample Gemfile
 source "https://rubygems.org"
 
-gem 'puppet', '< 4.0.0'
+if puppetversion = ENV['PUPPET_GEM_VERSION']
+      gem 'puppet', puppetversion
+else
+      gem 'puppet', '< 4.0.0'
+end
 
 gem 'rake'
 gem 'rspec'

--- a/Gemfile
+++ b/Gemfile
@@ -10,8 +10,11 @@ end
 gem 'rake'
 gem 'rspec'
 gem 'puppet-lint'
-gem 'beaker'
-gem 'beaker-rspec'
 gem 'rspec-puppet'
 gem 'puppetlabs_spec_helper'
 gem 'puppet-syntax'
+
+group :system_tests do
+  gem 'beaker'
+  gem 'beaker-rspec'
+end


### PR DESCRIPTION
This re-enables testing on puppet 4.0 which should work now in rspec-puppet 2.1.0+.

Also test the future parser on puppet 3.7.x as well as strict variables.

And finally exclude the beaker gems from the travis run to speed up the test runs.