### PR TITLE
fixed apt::source deprecation warning about key_content

### DIFF
--- a/manifests/repo/puppetlabs.pp
+++ b/manifests/repo/puppetlabs.pp
@@ -7,8 +7,10 @@ class puppet::repo::puppetlabs() {
   if($::osfamily == 'Debian') {
     Apt::Source {
       location    => 'http://apt.puppetlabs.com',
-      key         => '4BD6EC30',
-      key_content => template('puppet/pgp.key'),
+      key         => {
+        id          => '47B320EB4C7C375AA9DAE1A01054B7A24BD6EC30',
+        content     => template('puppet/pgp.key'),
+      },
     }
     apt::source { 'puppetlabs':      repos => 'main' }
     apt::source { 'puppetlabs-deps': repos => 'dependencies' }


### PR DESCRIPTION
When using the puppet::repo::puppetlabs class apt::source gives a deprecation warning about key_content:

    Warning: Scope(Apt::Source[puppetlabs]): $key_content is deprecated and will be removed in the next major release, please use $key => { 'content' => -----BEGIN PGP PUBLIC KEY BLOCK----- ....