### PR TITLE
Remove access_compat

### DIFF
--- a/manifests/passenger.pp
+++ b/manifests/passenger.pp
@@ -60,7 +60,6 @@ class puppet::passenger(
     trace_enable        => 'Off',
   }
 
-  apache::mod { 'access_compat': }
   apache::mod { 'status': package_ensure => 'absent' }
 
   include puppet::params


### PR DESCRIPTION
This is included by default in the apache module (https://github.com/puppetlabs/puppetlabs-apache/blob/master/manifests/default_mods.pp#L144) when apache version is >= 2.4 and including it this way breaks apache < 2.4.