### PR TITLE
Allow PassengerRoot directory to be supplied

### DIFF
--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -100,6 +100,7 @@ class puppet::master (
   $passenger_high_performance    = on,
   $passenger_max_requests        = 10000,
   $passenger_stat_throttle_rate  = 30,
+  $passenger_root                = undef,
   $serialization_format          = undef,
   $serialization_package         = undef,
 ) inherits puppet::params {
@@ -157,7 +158,7 @@ class puppet::master (
     passenger_high_performance    => $passenger_high_performance,
     passenger_max_requests        => $passenger_max_requests,
     passenger_stat_throttle_rate  => $passenger_stat_throttle_rate,
-
+    passenger_root                => $passenger_root,
   } ->
   Anchor['puppet::master::end']
 

--- a/manifests/passenger.pp
+++ b/manifests/passenger.pp
@@ -49,6 +49,7 @@ class puppet::passenger(
   $passenger_high_performance = 'off',
   $passenger_max_requests = 0,
   $passenger_stat_throttle_rate = 10,
+  $passenger_root,
 ){
 
   class { 'apache':
@@ -68,6 +69,7 @@ class puppet::passenger(
     passenger_high_performance   => $passenger_high_performance,
     passenger_max_requests       => $passenger_max_requests,
     passenger_stat_throttle_rate => $passenger_stat_throttle_rate,
+    passenger_root               => $passenger_root,
   }
 
   class { 'apache::mod::ssl':

--- a/spec/classes/puppet_passenger_spec.rb
+++ b/spec/classes/puppet_passenger_spec.rb
@@ -17,6 +17,7 @@ describe 'puppet::passenger', :type => :class do
                 :passenger_high_performance    => true,
                 :passenger_max_requests        => '1000',
                 :passenger_stat_throttle_rate  => '30',
+                :passenger_root                => nil,
         }
         end
     context 'on Debian' do
@@ -124,6 +125,7 @@ describe 'puppet::passenger', :type => :class do
           :passenger_high_performance    => true,
           :passenger_max_requests        => '1000',
           :passenger_stat_throttle_rate  => '30',
+          :passenger_root                => nil,
         }
       end
       it {


### PR DESCRIPTION
If you want to install a later version of Passenger on Ubuntu Precise, you need to set the PassengerRoot to what is expected by later versions of Passenger. This change allows you to supply this parameter to `apache::mod::passenger`.