### PR TITLE
Add support for Mac OS X

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -133,7 +133,7 @@ class puppet::agent(
       package { "puppet-${mac_version}.dmg":
         ensure   => present,
         provider => $package_provider,
-        source   => "https://downloads.puppetlabs.com/mac/puppet-${mac_version}.dmg'"
+        source   => "https://downloads.puppetlabs.com/mac/puppet-${mac_version}.dmg"
       }
     }
     default: {

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -125,12 +125,12 @@ class puppet::agent(
   }
   case $::osfamily {
     'Darwin': {
-      package {$puppet_facter_package:
+      package {"facter-${mac_facter_version}.dmg":
         ensure   => present,
         provider => $package_provider,
         source   => "https://downloads.puppetlabs.com/mac/facter-${mac_facter_version}.dmg",
       }
-      package { $puppet_agent_package:
+      package { "puppet-${mac_version}.dmg":
         ensure   => present,
         provider => $package_provider,
         source   => "https://downloads.puppetlabs.com/mac/puppet-${mac_version}.dmg'"

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -141,7 +141,7 @@ class puppet::agent(
         ensure   => $version,
         provider => $package_provider,
       }
-    }  
+    } 
   }
 
   if $puppet_run_style == 'service' {

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -6,6 +6,8 @@
 #   ['puppet_server']         - The dns name of the puppet master
 #   ['puppet_server_port']    - The Port the puppet master is running on
 #   ['puppet_agent_service']  - The service the puppet agent runs under
+#   ['mac_version']           - The package version for Mac OS X
+#   ['mac_facter_version']    - The Factor Version for Mac OS X
 #   ['puppet_agent_package']  - The name of the package providing the puppet agent
 #   ['version']               - The version of the puppet agent to install
 #   ['puppet_run_style']      - The run style of the agent either 'service', 'cron', 'external' or 'manual'
@@ -121,9 +123,25 @@ class puppet::agent(
       gid    => $group_id,
     }
   }
-  package { $puppet_agent_package:
-    ensure   => $version,
-    provider => $package_provider,
+  case $::osfamily {
+    'Darwin': {
+      package {$puppet_facter_package:
+        ensure   => present,
+        provider => $package_provider,
+        source   => "https://downloads.puppetlabs.com/mac/facter-${mac_facter_version}.dmg",
+      }
+      package { $puppet_agent_package:
+        ensure   => present,
+        provider => $package_provider,
+        source   => "https://downloads.puppetlabs.com/mac/puppet-${mac_version}.dmg'"
+      }
+    }
+    default: {
+      package { $puppet_agent_package:
+        ensure   => $version,
+        provider => $package_provider,
+      }
+    }  
   }
 
   if $puppet_run_style == 'service' {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -33,7 +33,6 @@ class puppet::params {
   $digest_algorithm                 = 'md5'
   $puppet_run_interval              = 30
   $classfile                        = '$statedir/classes.txt'
-  $package_provider                 = undef # falls back to system default
   $rundir                           = '/var/run/puppet'
   $puppet_passenger_ssl_protocol    = 'TLSv1.2'
   $puppet_passenger_ssl_cipher      = 'AES256+EECDH:AES256+EDH'
@@ -47,6 +46,7 @@ class puppet::params {
       $puppet_master_service        = 'puppetmaster'
       $puppet_agent_service         = 'puppet'
       $puppet_agent_package         = 'puppet'
+      $package_provider                 = undef # falls back to system default
       $puppet_defaults              = '/etc/sysconfig/puppet'
       $puppet_conf                  = '/etc/puppet/puppet.conf'
       $puppet_vardir                = '/var/lib/puppet'
@@ -60,6 +60,7 @@ class puppet::params {
       $puppet_master_service        = 'puppetmasterd'
       $puppet_agent_service         = 'puppet'
       $puppet_agent_package         = 'puppet'
+      $package_provider                 = undef # falls back to system default
       $puppet_conf                  = '/etc/puppet/puppet.conf'
       $puppet_vardir                = '/var/lib/puppet'
       $puppet_ssldir                = '/var/lib/puppet/ssl'
@@ -71,6 +72,7 @@ class puppet::params {
       $puppet_master_service        = 'puppetmaster'
       $puppet_agent_service         = 'puppet'
       $puppet_agent_package         = 'puppet'
+      $package_provider                 = undef # falls back to system default
       $puppet_defaults              = '/etc/default/puppet'
       $puppet_conf                  = '/etc/puppet/puppet.conf'
       $puppet_vardir                = '/var/lib/puppet'
@@ -82,13 +84,16 @@ class puppet::params {
     'FreeBSD': {
       $puppet_agent_service         = 'puppet'
       $puppet_agent_package         = 'sysutils/puppet'
+      $package_provider                 = undef # falls back to system default
       $puppet_conf                  = '/usr/local/etc/puppet/puppet.conf'
       $puppet_vardir                = '/var/puppet'
       $puppet_ssldir                = '/var/puppet/ssl'
     }
     'Darwin': {
       $puppet_agent_service         = 'com.puppetlabs.puppet'
-      $puppet_agent_package         = 'puppet'
+      $puppet_agent_package         = 'puppet-3.8.4.dmg'
+      $puppet_facter_package        = 'facter.2.4.4.dmg'
+      $package_provider             = 'pkgdmg'
       $puppet_conf                  = '/etc/puppet/puppet.conf'
       $puppet_vardir                = '/var/lib/puppet'
       $puppet_ssldir                = '/etc/puppet/ssl'


### PR DESCRIPTION
I added some additional parameters to make the OS X support functional. It currently works with the cron run style since this is what I use in my environment. In order to fully support the service run style on OS X the creating of the launchd file will need to be added to the module.