### PR TITLE
Added show_diff param

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -27,6 +27,7 @@
 #   ['trusted_node_data']     - Enable the trusted facts hash
 #   ['listen']                - If puppet agent should listen for connections
 #   ['reportserver']          - The server to send transaction reports to.
+#   ['show_diff']             - Should the reports contain diff output
 #   ['digest_algorithm']      - The algorithm to use for file digests.
 #   ['templatedir']           - Template dir, if unset it will remove the setting.
 #   ['configtimeout']         - How long the client should wait for the configuration to be retrieved before considering it a failure
@@ -90,6 +91,7 @@ class puppet::agent(
   $pluginsync             = true,
   $listen                 = false,
   $reportserver           = '$server',
+  $show_diff              = undef,
   $digest_algorithm       = $::puppet::params::digest_algorithm,
   $configtimeout          = '2m',
   $stringify_facts        = undef,
@@ -271,6 +273,19 @@ class puppet::agent(
       section => 'main',
       setting => 'ssldir',
       value   => $puppet_ssldir,
+    }
+  }
+  if $show_diff != undef {
+    ini_setting {'puppetagentshow_diff':
+      ensure  => present,
+      section => 'main',
+      setting => 'show_diff',
+      value   => $show_diff,
+    }
+    unless defined(Package[$::puppet::params::ruby_diff_lcs]) {
+      package {$::puppet::params::ruby_diff_lcs:
+        ensure  => 'latest',
+      }
     }
   }
   

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -54,6 +54,7 @@ class puppet::params {
       $passenger_package            = 'mod_passenger'
       $rack_package                 = 'rubygem-rack'
       $ruby_dev                     = 'ruby-devel'
+      $ruby_diff_lcs                = 'rubygem-diff-lcs'
     }
     'Suse': {
       $puppet_master_package        = 'puppet-server'
@@ -65,6 +66,7 @@ class puppet::params {
       $puppet_ssldir                = '/var/lib/puppet/ssl'
       $passenger_package            = 'rubygem-passenger-apache2'
       $rack_package                 = 'rubygem-rack'
+      $ruby_diff_lcs                = 'rubygem-diff-lcs'
     }
     'Debian': {
       $puppet_master_package        = 'puppetmaster'
@@ -78,6 +80,7 @@ class puppet::params {
       $passenger_package            = 'libapache2-mod-passenger'
       $rack_package                 = 'librack-ruby'
       $ruby_dev                     = 'ruby-dev'
+      $ruby_diff_lcs                = 'ruby-diff-lcs'
     }
     'FreeBSD': {
       $puppet_agent_service         = 'puppet'

--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -551,6 +551,32 @@ describe 'puppet::agent', :type => :class do
       }
     end
   end
+  describe 'puppetagentshow_diff' do
+    let(:facts) do
+      {
+        :osfamily        => 'RedHat',
+        :operatingsystem => 'RedHat',
+        :kernel          => 'Linux'
+      }
+    end
+    context 'with show_diff set' do
+      let(:params) do
+        {
+          :show_diff        => true,
+        }
+      end
+
+      it{
+        should contain_ini_setting('puppetagentshow_diff').with(
+          :ensure  => 'present',
+          :section => 'main',
+          :setting => 'show_diff',
+          :value   => true,
+          :path    => '/etc/puppet/puppet.conf'
+        )
+      }
+    end
+  end
   describe 'puppetagentstringifyfacts' do
     let(:facts) do
       {


### PR DESCRIPTION
I personally prefer to have show_diff output enable/disable config per host.  This patch allows me to set it, but defaults to leaving it unmanaged.
