### PR TITLE
Add option to disable/enable apache::mod status

### DIFF
--- a/manifests/master.pp
+++ b/manifests/master.pp
@@ -101,6 +101,7 @@ class puppet::master (
   $passenger_max_requests        = 10000,
   $passenger_stat_throttle_rate  = 30,
   $passenger_root                = undef,
+  $passenger_disable_mod_status  = true,
   $serialization_format          = undef,
   $serialization_package         = undef,
 ) inherits puppet::params {
@@ -159,6 +160,7 @@ class puppet::master (
     passenger_max_requests        => $passenger_max_requests,
     passenger_stat_throttle_rate  => $passenger_stat_throttle_rate,
     passenger_root                => $passenger_root,
+    passenger_disable_mod_status  => $passenger_disable_mod_status,
   } ->
   Anchor['puppet::master::end']
 

--- a/manifests/passenger.pp
+++ b/manifests/passenger.pp
@@ -50,6 +50,7 @@ class puppet::passenger(
   $passenger_max_requests = 0,
   $passenger_stat_throttle_rate = 10,
   $passenger_root,
+  $passenger_disable_mod_status = true,
 ){
 
   class { 'apache':
@@ -61,7 +62,9 @@ class puppet::passenger(
     trace_enable        => 'Off',
   }
 
-  apache::mod { 'status': package_ensure => 'absent' }
+  if $passenger_disable_mod_status {
+    apache::mod { 'status': package_ensure => 'absent' }
+  }
 
   include puppet::params
   class { 'apache::mod::passenger':


### PR DESCRIPTION
We define configuration of `apache::mod { 'status': }` elsewhere, so it conflict.  Here an option to let you manage it yourself