### PR TITLE
update repository keys

### DIFF
--- a/manifests/repo/puppetlabs.pp
+++ b/manifests/repo/puppetlabs.pp
@@ -8,7 +8,7 @@ class puppet::repo::puppetlabs() {
     Apt::Source {
       location    => 'http://apt.puppetlabs.com',
       key         => {
-        'id'     => '47B320EB4C7C375AA9DAE1A01054B7A24BD6EC30',
+        'id'     => '6F6B15509CF8E59E6E469F327F438280EF8D349F',
         'server' => 'pgp.mit.edu',
       },
     }
@@ -27,7 +27,7 @@ class puppet::repo::puppetlabs() {
       descr    => 'Puppet Labs Dependencies $releasever - $basearch ',
       enabled  => '1',
       gpgcheck => '1',
-      gpgkey   => 'http://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs',
+      gpgkey   => 'https://yum.puppetlabs.com/RPM-GPG-KEY-puppet',
     }
 
     yumrepo { 'puppetlabs':
@@ -35,7 +35,7 @@ class puppet::repo::puppetlabs() {
       descr    => 'Puppet Labs Products $releasever - $basearch',
       enabled  => '1',
       gpgcheck => '1',
-      gpgkey   => 'http://yum.puppetlabs.com/RPM-GPG-KEY-puppetlabs',
+      gpgkey   => 'https://yum.puppetlabs.com/RPM-GPG-KEY-puppet',
     }
   } else {
     fail("Unsupported osfamily ${::osfamily}")


### PR DESCRIPTION
Update Deb and Yum repository keys to point to the new
7F438280EF8D349F key.
Additionally use HTTPS when fetching keys with Yum to decrease
MITM risk, since we don't check if the downloaded key matches
the expected keyid.

See: https://puppet.com/blog/updated-puppet-gpg-signing-key