### PR TITLE
Fix facter package for Darwin

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -92,7 +92,7 @@ class puppet::params {
     'Darwin': {
       $puppet_agent_service         = 'com.puppetlabs.puppet'
       $puppet_agent_package         = 'puppet-3.8.5.dmg'
-      $puppet_facter_package        = 'facter.2.4.5.dmg'
+      $puppet_facter_package        = 'facter-2.4.5.dmg'
       $package_provider             = 'pkgdmg'
       $puppet_conf                  = '/etc/puppet/puppet.conf'
       $puppet_vardir                = '/var/lib/puppet'


### PR DESCRIPTION
Using this module on macos result in this error.

```
Error: Could not set 'present' on ensure: No such file or directory - https://downloads.puppetlabs.com/mac/facter.2.4.5.dmg at 138:/puppet-files/modules/puppet/manifests/agent.pp
```
Indeed, `https://downloads.puppetlabs.com/mac/facter.2.4.5.dmg` is not correct. The correct url is `https://downloads.puppetlabs.com/mac/facter-2.4.5.dmg`.