### PR TITLE
patch: make cronjob time dependent on IP address

### DIFF
--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -227,7 +227,7 @@ class puppet::agent(
         # cron_minute = 'ip:130.10.21.2/16%300'  # mod 300
         # cron_minute = 'ip:%{::ip_address}/22'
 
-        $cron_minute_ip = pick($1,getvar($::ipaddress),"127.0.0.1")
+        $cron_minute_ip = pick($1,getvar('::ipaddress'),"127.0.0.1")
         $cron_minute_mask = pick($2,24)
         $cron_minute_mod = pick($3,60)
         $minute = inline_template('<%=

--- a/manifests/agent.pp
+++ b/manifests/agent.pp
@@ -227,7 +227,7 @@ class puppet::agent(
         # cron_minute = 'ip:130.10.21.2/16%300'  # mod 300
         # cron_minute = 'ip:%{::ip_address}/22'
 
-        $cron_minute_ip = pick($1,$::ipaddress,"127.0.0.1")
+        $cron_minute_ip = pick($1,getvar($::ipaddress),"127.0.0.1")
         $cron_minute_mask = pick($2,24)
         $cron_minute_mod = pick($3,60)
         $minute = inline_template('<%=

--- a/spec/classes/puppet_agent_spec.rb
+++ b/spec/classes/puppet_agent_spec.rb
@@ -69,7 +69,7 @@ describe 'puppet::agent', :type => :class do
             :enable  => false,
             :require => "Package[#{params[:puppet_agent_package]}]"
           )
-          should contain_cron('puppet-client').with(
+          should contain_cron('puppet-agent').with(
             :command  => '/usr/bin/puppet agent --no-daemonize --onetime --logdest syslog > /dev/null 2>&1',
             :user     => 'root',
             :hour     => '5',
@@ -77,6 +77,76 @@ describe 'puppet::agent', :type => :class do
           )
         }
       end
+      context 'using cron-with-ip1' do
+        let(:params) do
+          {
+            :puppet_server          => 'test.exaple.com',
+            :puppet_agent_service   => 'puppet',
+            :puppet_agent_package   => 'puppet',
+            :version                => '/etc/puppet/manifests/site.pp',
+            :puppet_run_style       => 'cron',
+            :splay                  => 'true',
+            :environment            => 'production',
+            :puppet_server_port     => 8140,
+	    :cron_minute => 'ip:10.2.3.44/8%60', # (2*256*256+3*256+44)%60 = 4
+          }
+        end
+        it{
+          should contain_cron('puppet-agent').with(
+            :command  => '/usr/bin/puppet agent --no-daemonize --onetime --logdest syslog > /dev/null 2>&1',
+            :user     => 'root',
+            :hour     => '*',
+            :minute   => '4'
+          )
+        }
+      end
+      context 'using cron-with-ip2' do
+        let(:params) do
+          {
+            :puppet_server          => 'test.exaple.com',
+            :puppet_agent_service   => 'puppet',
+            :puppet_agent_package   => 'puppet',
+            :version                => '/etc/puppet/manifests/site.pp',
+            :puppet_run_style       => 'cron',
+            :splay                  => 'true',
+            :environment            => 'production',
+            :puppet_server_port     => 8140,
+	    :cron_minute => 'ip:10.2.3.44/16%300', # .. (3*256+44)%300 = 212
+          }
+        end
+        it{
+          should contain_cron('puppet-agent').with(
+            :command  => '/usr/bin/puppet agent --no-daemonize --onetime --logdest syslog > /dev/null 2>&1',
+            :user     => 'root',
+            :hour     => '*',
+            :minute   => '212'
+          )
+        }
+      end
+      context 'using cron-with-ip3' do
+        let(:params) do
+          {
+            :puppet_server          => 'test.exaple.com',
+            :puppet_agent_service   => 'puppet',
+            :puppet_agent_package   => 'puppet',
+            :version                => '/etc/puppet/manifests/site.pp',
+            :puppet_run_style       => 'cron',
+            :splay                  => 'true',
+            :environment            => 'production',
+            :puppet_server_port     => 8140,
+	    :cron_minute            => 'ip/0', # .. (127*256*256+1)%60 = 53
+          }
+        end
+        it{
+          should contain_cron('puppet-agent').with(
+            :command  => '/usr/bin/puppet agent --no-daemonize --onetime --logdest syslog > /dev/null 2>&1',
+            :user     => 'root',
+            :hour     => '*',
+            :minute   => '53'
+          )
+        }
+      end
+
     end
 
     describe 'srv records on Debian' do
@@ -230,7 +300,7 @@ describe 'puppet::agent', :type => :class do
             :enable  => false,
             :require => "Package[#{params[:puppet_agent_package]}]"
           )
-          should contain_cron('puppet-client').with(
+          should contain_cron('puppet-agent').with(
             :command  => '/usr/bin/puppet agent --no-daemonize --onetime --logdest syslog > /dev/null 2>&1',
             :user  => 'root',
             :hour => '*'


### PR DESCRIPTION
If agent-mode is set to `cron`, then `cron_minute` may be set to `ip`. The actual minute used in the cron job will be determined by the numeric value of the IP address, mod 60. The IP address is assumed from the global fact `::ipaddress` but may be specified with `ip:ADDRESS`. The first 24 bits of the IP address are masked, but the mask may be specified with `ip/MASK` or `ip:ADDRESS/MASK`. For example:

    $puppet_run_style => 'cron',
    $cron_minute => 'ip:10.2.9.63/16',

It will run on the 27th minute. 

WARNING: Renames puppet-client" to "puppet-agent" for purposes of labeling the cronjob entry.
